### PR TITLE
Various changes

### DIFF
--- a/pgprogress.sh
+++ b/pgprogress.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Enter Database Name to check against
-DBNAME="postgres"
 MPPID=$1
 
 # Error check input
@@ -10,6 +8,10 @@ if [ $# -eq 0 ]
     echo "No PID supplied"
     exit
 fi
+
+# Determine the database being used by the process we're interrested in 
+DBNAME=`psql -Atc "select datname from pg_stat_activity where pid = $MPPID"`
+QUERY=`psql -Atc "select query from pg_stat_activity where pid = $MPPID"`
 
 #functions
 
@@ -29,7 +31,7 @@ function getfname {
 #Build read or write lists and flag if temp file is in list
 function buildlists {
 	local FTYPE=$1
-	MFILE=`grep $FTYPE proctrace.txt |awk -F',' {'print $1;'}|awk -F"(" {'print $2;'}|sort|uniq|xargs`
+	MFILE=`grep $FTYPE /tmp/proctrace.txt |awk -F',' {'print $1;'}|awk -F"(" {'print $2;'}|sort|uniq|xargs`
 	NUMMFILE=`echo $MFILE|wc -w`
 	
 	for IOFNAME in $MFILE
@@ -55,10 +57,10 @@ function printlists {
 	#echo "DEBUG IOFILES $IOFILES RFIES $RFILES WFILES $WFILES"
 	for IOFILE in $IOFILES
 	do
-		ONFILE=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->"|awk -F"-> " {'print $2;'}|awk -F"/" {'print $6;'}|awk -F"." {'print $1;'}`
+		ONFILE=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->" | grep -oP '(?<=/)\d+(?=\.\d+$)'`
                 ONSUBFILE=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->"|awk -F . '{print $NF}'`
                 FULLNAME=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->"|awk -F"-> " {'print $2;'}`
-                MDIR=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->"|awk -F"-> " {'print $2;'}|awk -F"/" {'print $1"/"$2"/"$3"/"$4"/"$5;'}`
+                MDIR=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->" | grep -oP '(?<=\s)/.*(?=/[^/]+$)'`
 		MAXSUBFILE=`ls -alv $MDIR |grep $ONFILE|grep -v "_vm"|grep -v "_fsm"|tail -n1|awk -F . '{print $NF}'`
 		isonlygig 
 		getfname $ONFILE
@@ -77,11 +79,11 @@ function isonlygig {
 
 
 #Main
-echo "Checking process $MPPID"
+echo "Checking process $MPPID ($QUERY)"
 echo $(date)
 echo
 
-timeout 1 strace -o proctrace.txt -p $MPPID &>/dev/null
+timeout 2 strace -o /tmp/proctrace.txt -p $MPPID &>/dev/null
 buildlists read
 buildlists write
 

--- a/pgprogress.sh
+++ b/pgprogress.sh
@@ -17,15 +17,8 @@ QUERY=`psql -Atc "select query from pg_stat_activity where pid = $MPPID"`
 
 #Take in ONFILE raw numeric file and output relfilname
 function getfname {
-	local ONFILE=$1
-	if [[ $ONFILE =~ .*_fsm.* ]]; then
-		ONFILE="UNKNOWN";
-	elif [[ $ONFILE =~ .*pg_xlog.* ]]; then
-		ONFILE="UNKNOWN";
-	fi
-	if [ "$ONFILE" != "UNKNOWN" ]; then
-		OIDNAME=`psql -t -d $DBNAME -c "SELECT relname from pg_class where relfilenode = $ONFILE;"`
-	fi	
+  #echo "psql -U postgres -t -d $DBNAME -c 'SELECT relname from pg_class where relfilenode = $ONFILE;'"
+  OIDNAME=`psql -U postgres -t -d $DBNAME -c "SELECT relname from pg_class where relfilenode = $ONFILE;" 2>&1`
 }
 
 #Build read or write lists and flag if temp file is in list
@@ -57,14 +50,37 @@ function printlists {
 	#echo "DEBUG IOFILES $IOFILES RFIES $RFILES WFILES $WFILES"
 	for IOFILE in $IOFILES
 	do
-		ONFILE=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->" | grep -oP '(?<=/)\d+(?=\.\d+$)'`
-                ONSUBFILE=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->"|awk -F . '{print $NF}'`
-                FULLNAME=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->"|awk -F"-> " {'print $2;'}`
-                MDIR=`ls -l /proc/$MPPID/fd |grep " $IOFILE ->" | grep -oP '(?<=\s)/.*(?=/[^/]+$)'`
-		MAXSUBFILE=`ls -alv $MDIR |grep $ONFILE|grep -v "_vm"|grep -v "_fsm"|tail -n1|awk -F . '{print $NF}'`
+                #echo $IOFILE
+		#echo "ls -l /proc/$MPPID/fd/$IOFILE | grep -oP '(?<=/)[^/.]+(?=(\.\d+)?$)'"
+	        ONFILE=`ls -l /proc/$MPPID/fd/$IOFILE | grep -oP '(?<=/)[^/.]+(?=(\.\d+)?$)'`
+                FULLNAME=`ls -l /proc/$MPPID/fd/$IOFILE | awk -F'-> ' {'print $2;'}`
+		#echo "O $ONFILE F $FULLNAME"
+		if [[ "$FULLNAME" =~ \. ]]; then
+                  ONSUBFILE=`ls -l /proc/$MPPID/fd/$IOFILE | awk -F . '{print $NF}'`
+                  #echo "ls -l /proc/$MPPID/fd/$IOFILE | grep -oP '(?<=\s)/[^ ]*(?=/[^/]+$)'"
+                  MDIR=`ls -l /proc/$MPPID/fd/$IOFILE | grep -oP '(?<=\s)/[^ ]*(?=/[^/]+$)'`
+                  #echo "ls -alv $MDIR |grep $ONFILE|grep -v '_vm'|grep -v '_fsm'|tail -n1|awk -F . '{print $NF}'"
+  		  MAXSUBFILE=`ls -alv $MDIR |grep $ONFILE|grep -v "_vm"|grep -v "_fsm"|tail -n1|awk -F . '{print $NF}'`
+                else 
+		  ONSUBFILE=1
+		  MAXSUBFILE=1
+                fi
+
 		isonlygig 
-		getfname $ONFILE
-                echo "Process I/O is in $OIDNAME at $ONSUBFILE out of $MAXSUBFILE at $FULLNAME"
+		#echo "ONFILE: $IOFILE $ONFILE"
+                if [[ "$FULLNAME" =~ pg_xlog ]] || [[ "$FULLNAME" =~ pg_wal ]]; then 
+                    OIDNAME=" <wal:$ONFILE>"
+                elif [[ "$FULLNAME" =~ pgsql_tmp ]]; then
+                    OIDNAME=" <tmp:$ONFILE>"
+		elif [[ "$FULLNAME" =~ _fsm ]]; then
+		    OIDNAME=" <fsm:$ONFILE>"
+                else 
+                    getfname $ONFILE
+		    if [[ -z $OIDNAME ]]; then
+                        OIDNAME=" <unknown:$ONFILE>"
+                    fi
+                fi
+                echo "Process I/O is in$OIDNAME at $ONSUBFILE out of $MAXSUBFILE at $FULLNAME"
 	done
 }
 


### PR DESCRIPTION
Make the script:
 work with postgres when installed to a non-standard location
 strace for 2 seconds rather than 1
 write the strace output to /tmp rather than pwd
 pull the database name from pg_stat_activity
 print the query being executed by the pid specified